### PR TITLE
Doubled time-out value of sbatch get-user-env argument 

### DIFF
--- a/templates/slurm/header.ftl
+++ b/templates/slurm/header.ftl
@@ -7,7 +7,7 @@
 #SBATCH --mem ${mem}
 #SBATCH --open-mode=append
 #SBATCH --export=NONE
-#SBATCH --get-user-env=30L
+#SBATCH --get-user-env=60L
 
 set -e
 set -u

--- a/templates/slurm/header_tnt.ftl
+++ b/templates/slurm/header_tnt.ftl
@@ -7,7 +7,7 @@
 #SBATCH --mem ${mem}
 #SBATCH --open-mode=append
 #SBATCH --export=NONE
-#SBATCH --get-user-env=30L
+#SBATCH --get-user-env=60L
 
 set -e
 set -u


### PR DESCRIPTION
Doubled time-out value of sbatch get-user-env argument to prevent ```module: command not found errors``` on clusters with slower file systems.